### PR TITLE
Test fixes

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -8,7 +8,7 @@ from pycodestyle import Checker, StyleGuide
 import pylint.lint
 
 ROOT_PATH = os.path.join(os.path.dirname(__file__), '..')
-MODULES_TO_CHECK = ['cbor', 'examples', 'scripts']
+MODULES_TO_CHECK = ['cbor', 'examples', 'scripts', 'tests']
 PEP8_OPTIONS = StyleGuide(
     config_file=os.path.join(ROOT_PATH, 'setup.cfg')
 ).options

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [pycodestyle]
-ignore = E121, E123, E126, E226, E24, E704, W503, E402
+ignore = E121, E123, E126, E226, E24, E704, W503, E402, E251
 max-line-length = 80

--- a/tests/test_MajorType.py
+++ b/tests/test_MajorType.py
@@ -7,24 +7,26 @@ from io import RawIOBase, BytesIO
 from cbor.MajorType import MajorType
 from cbor.CBORStream import CBORStream
 
+
 def test_run_uint():
     mt = MajorType()
     data = CBORStream(BytesIO(bytes([0b00010101])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
     data = CBORStream(BytesIO(bytes([0b00000000])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
     data = CBORStream(BytesIO(bytes([0b00010111])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
     data = CBORStream(BytesIO(bytes([0b00011111])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
+
 
 def test_run_int():
     mt = MajorType()
     data = CBORStream(BytesIO(bytes([0b00110101])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
     data = CBORStream(BytesIO(bytes([0b00100000])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
     data = CBORStream(BytesIO(bytes([0b00110111])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None
     data = CBORStream(BytesIO(bytes([0b00111111])))
-    assert mt.run(data, None) == None
+    assert mt.run(data, None) is None

--- a/tests/test_Stack.py
+++ b/tests/test_Stack.py
@@ -10,12 +10,23 @@ def test_init():
     stack = Stack()
     assert stack.items == []
 
+<<<<<<< HEAD
 def test_isEmpty():
     stack = Stack()
     assert stack.isEmpty() == True
     stack = Stack()
     stack.push(10)
     assert stack.isEmpty() == False
+=======
+
+def test_isEmpty():
+    stack = Stack()
+    assert stack.isEmpty() is True
+    stack = Stack()
+    stack.push(10)
+    assert stack.isEmpty() is False
+
+>>>>>>> adds E251 to ignored errors and makes tests pass the linter
 
 def test_push():
     stack = Stack()
@@ -24,6 +35,10 @@ def test_push():
     stack.push('test')
     assert stack.items == [5, 'test']
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_push_array():
     stack = Stack()
     stack.push([3, 4])
@@ -31,6 +46,10 @@ def test_push_array():
     stack.push(['test', [5, 6]])
     assert stack.items == [3, 4, 'test', [5, 6]]
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_pop():
     stack = Stack()
     stack.push([1, 3, 4])
@@ -40,12 +59,20 @@ def test_pop():
     with pytest.raises(Exception):
         stack.pop()
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_peek():
     stack = Stack()
     stack.push([1, 3, 4])
     assert stack.peek() == 4
     assert stack.items == [1, 3, 4]
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_size():
     stack = Stack()
     stack.push(5)

--- a/tests/test_Stack.py
+++ b/tests/test_Stack.py
@@ -10,14 +10,6 @@ def test_init():
     stack = Stack()
     assert stack.items == []
 
-<<<<<<< HEAD
-def test_isEmpty():
-    stack = Stack()
-    assert stack.isEmpty() == True
-    stack = Stack()
-    stack.push(10)
-    assert stack.isEmpty() == False
-=======
 
 def test_isEmpty():
     stack = Stack()
@@ -26,7 +18,6 @@ def test_isEmpty():
     stack.push(10)
     assert stack.isEmpty() is False
 
->>>>>>> adds E251 to ignored errors and makes tests pass the linter
 
 def test_push():
     stack = Stack()
@@ -35,10 +26,7 @@ def test_push():
     stack.push('test')
     assert stack.items == [5, 'test']
 
-<<<<<<< HEAD
-=======
 
->>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_push_array():
     stack = Stack()
     stack.push([3, 4])
@@ -46,10 +34,7 @@ def test_push_array():
     stack.push(['test', [5, 6]])
     assert stack.items == [3, 4, 'test', [5, 6]]
 
-<<<<<<< HEAD
-=======
 
->>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_pop():
     stack = Stack()
     stack.push([1, 3, 4])
@@ -59,20 +44,14 @@ def test_pop():
     with pytest.raises(Exception):
         stack.pop()
 
-<<<<<<< HEAD
-=======
 
->>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_peek():
     stack = Stack()
     stack.push([1, 3, 4])
     assert stack.peek() == 4
     assert stack.items == [1, 3, 4]
 
-<<<<<<< HEAD
-=======
 
->>>>>>> adds E251 to ignored errors and makes tests pass the linter
 def test_size():
     stack = Stack()
     stack.push(5)


### PR DESCRIPTION
This pr makes the linter lint the test files as well, and also fixes the issues that came up with them. The error E251 will be also ignored, since it forces the code to be less legible.
See:
```
def foo(x=None)      # OK before
def foo(x = None)    # not OK before
```